### PR TITLE
Fix robots continue moving after their destination is reached

### DIFF
--- a/src/5_control/src/libs/control_handle.cpp
+++ b/src/5_control/src/libs/control_handle.cpp
@@ -214,7 +214,7 @@ namespace control {
             }
 
             for (int robot=0; robot<3; robot++) {
-                if (path_[robot].points.empty()) {
+                if (path_[robot].points.empty() || finito[robot]) {
                     finito[robot] = true;
                     continue;
                 }


### PR DESCRIPTION
### Problem
It seems there's a problem when dealing with multiple robots. Basically, every robot keeps moving until everyone has reached the final destination.

### How to reproduce
Spawn two robots, create a long path for the first and a short path for the second. The second robot will continue moving even after having reached its final destination.

### Fix
With this update, a robot correctly stops when it reaches its own destination.